### PR TITLE
throwing away `isolate_namespace`

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,8 +63,8 @@ If `item.owner` exists, it is used as `auction.seller` (or Select from all aucit
 - auctioneer can define format of auction numbers (eg. "YY#####") and sales_pack numbers
 - there should be ability to follow `auction` (notification before end) or `item.author` (new item in auction)
 - item can have category and user can select auction by categories.
-- AuctionPack can be `(un)published /public`
-- AuctionPack can be `open (adding items , bidding)/ closed(bidding ended)`
+- SalePack can be `(un)published /public`
+- SalePack can be `open (adding items , bidding)/ closed(bidding ended)`
 - auctioneer_commission is in % and adds to sold_price in checkout
 - auction have `start_time` and `end_time`
 - auction can be `highlighted` for cover pages
@@ -72,6 +72,8 @@ If `item.owner` exists, it is used as `auction.seller` (or Select from all aucit
 - there should be two types of bid
    - one with maximal price (amount =>  maximal bid price; placed in small bids as needed), system will increase bid automagicaly unless it reaches maximum
    - second direct bid (amount => bid price; immediattely placed)
+- sales numbering: YY#### (210001, 210002, …, 259999)
+
 
 
 

--- a/README.md
+++ b/README.md
@@ -4,13 +4,13 @@ Rails engine for auctions of items. Can be used on any ActiveRecord models.
 ## Objects
 - `:item` - object/model, which should be auctioned (from `main_app`)
 - `:user` - source for `seller`, `owner`, `buyer` and `bidder` (from `main_app`)
-- `sale` - sale of `:item`; can be direct `retail`, by `auction` or some other way
+- `sale` - sale of `:item`; can be direct `retail`, by `auction` or some other type
 - `auction` for one `:item` (it is [Forward auction](https://en.wikipedia.org/wiki/Forward_auction)) (v češtině "Položka aukce")
 - `seller` - person/company which sells `:item` in specific `sale`
 - `bidder` - registered person/user allowed to bid in specific `auction`
 - `buyer` - person/company which buys `:item` in specific `sale` ( eg. winner of auction)
 - `bid` - one bid of one `bidder` in `auction`
-- `sales_pack` - pack of sales/auctions, mostly time framed, Can have physical location or be online. (v češtině "Aukce")
+- `sales_pack` - pack of sales(auctions), mostly time framed, Can have physical location or be online. (v češtině "Aukce")
 - `auctioneer` - (needed?) company organizing `auction`
 
 ## Relations
@@ -19,7 +19,7 @@ Rails engine for auctions of items. Can be used on any ActiveRecord models.
 - `sale` N : 1 `seller`
 - `sale` N : 1 `buyer`
 - `sale::auction` 1 : N `bidders` (trough `bidder_registrations`) 1 : N `bids`
-- `sales_pack` 0-1 : N `auctions`  (`sales_pack` is optional for `auction`)
+- `sales_pack` 0-1 : N `sales`  (`sales_pack` is optional for `sale`)
 - `auction` N : 1 `auctioneer` (?)
 
 

--- a/app/concerns/auctify/behavior/item.rb
+++ b/app/concerns/auctify/behavior/item.rb
@@ -9,7 +9,7 @@ module Auctify
 
       included do
         has_many :sales, as: :item, class_name: "Auctify::Sale::Base"
-        has_many :auctions, as: :item, class_name: "Auctify::Sale::Auction"
+        has_many :auction_sales, as: :item, class_name: "Auctify::Sale::Auction"
         has_many :retail_sales, as: :item, class_name: "Auctify::Sale::Retail"
       end
     end

--- a/app/concerns/auctify/behavior/seller.rb
+++ b/app/concerns/auctify/behavior/seller.rb
@@ -9,11 +9,11 @@ module Auctify
 
       included do
         has_many :sales, as: :seller, class_name: "Auctify::Sale::Base"
-        has_many :auctions, as: :seller, class_name: "Auctify::Sale::Auction"
+        has_many :auction_sales, as: :seller, class_name: "Auctify::Sale::Auction"
         has_many :retail_sales, as: :seller, class_name: "Auctify::Sale::Retail"
 
         def offer_to_sale!(item, options = {})
-          assoc = options[:in] == :auction ? auctions : retail_sales
+          assoc = options[:in] == :auction ? auction_sales : retail_sales
           assoc.create!(item: item,
                         seller: self,
                         buyer: nil,

--- a/app/controllers/auctify/application_controller.rb
+++ b/app/controllers/auctify/application_controller.rb
@@ -3,5 +3,6 @@
 module Auctify
   class ApplicationController < ActionController::Base
     protect_from_forgery with: :exception
+    include Auctify::ApplicationHelper
   end
 end

--- a/app/controllers/auctify/bidder_registrations_controller.rb
+++ b/app/controllers/auctify/bidder_registrations_controller.rb
@@ -47,7 +47,7 @@ module Auctify
     # DELETE /bidder_registrations/1
     def destroy
       @bidder_registration.destroy
-      redirect_to bidder_registrations_url, notice: "Bidder registration was successfully destroyed."
+      redirect_to auctify_bidder_registrations_url, notice: "Bidder registration was successfully destroyed."
     end
 
     private

--- a/app/controllers/auctify/bids_controller.rb
+++ b/app/controllers/auctify/bids_controller.rb
@@ -47,7 +47,7 @@ module Auctify
     # DELETE /bids/1
     def destroy
       @bid.destroy
-      redirect_to bids_url, notice: "Bid was successfully destroyed."
+      redirect_to auctify_bids_url, notice: "Bid was successfully destroyed."
     end
 
     private

--- a/app/controllers/auctify/sales_controller.rb
+++ b/app/controllers/auctify/sales_controller.rb
@@ -38,7 +38,6 @@ module Auctify
     # PATCH/PUT /sales/1
     def update
       if @sale.update(sale_params)
-        binding.pry
         redirect_to auctify_sale_path(@sale), notice: "Sale was successfully updated."
       else
         render :edit
@@ -48,7 +47,7 @@ module Auctify
     # DELETE /sales/1
     def destroy
       @sale.destroy
-      redirect_to sales_url, notice: "Sale was successfully destroyed."
+      redirect_to auctify_sales_url, notice: "Sale was successfully destroyed."
     end
 
     private

--- a/app/controllers/auctify/sales_controller.rb
+++ b/app/controllers/auctify/sales_controller.rb
@@ -29,7 +29,7 @@ module Auctify
       @sale = sale_class.new(sale_params)
 
       if @sale.save
-        redirect_to sale_path(@sale), notice: "Sale was successfully created."
+        redirect_to auctify_sale_path(@sale), notice: "Sale was successfully created."
       else
         render :new
       end
@@ -38,7 +38,8 @@ module Auctify
     # PATCH/PUT /sales/1
     def update
       if @sale.update(sale_params)
-        redirect_to sale_path(@sale), notice: "Sale was successfully updated."
+        binding.pry
+        redirect_to auctify_sale_path(@sale), notice: "Sale was successfully updated."
       else
         render :edit
       end

--- a/app/controllers/auctify/sales_packs_controller.rb
+++ b/app/controllers/auctify/sales_packs_controller.rb
@@ -47,7 +47,7 @@ module Auctify
     # DELETE /sales_packs/1
     def destroy
       @sales_pack.destroy
-      redirect_to sales_packs_url, notice: "Sales pack was successfully destroyed."
+      redirect_to auctify_sales_packs_url, notice: "Sales pack was successfully destroyed."
     end
 
     private

--- a/app/helpers/auctify/application_helper.rb
+++ b/app/helpers/auctify/application_helper.rb
@@ -2,5 +2,6 @@
 
 module Auctify
   module ApplicationHelper
+    include Auctify::Engine.routes.url_helpers
   end
 end

--- a/app/helpers/auctify/application_helper.rb
+++ b/app/helpers/auctify/application_helper.rb
@@ -3,5 +3,8 @@
 module Auctify
   module ApplicationHelper
     include Auctify::Engine.routes.url_helpers
+    # line above somehow breaks url generation in forms from main_app
+    # so we nedd to ensure main_app supremacy
+    include Rails.application.routes.url_helpers
   end
 end

--- a/app/models/auctify/application_record.rb
+++ b/app/models/auctify/application_record.rb
@@ -3,5 +3,6 @@
 module Auctify
   class ApplicationRecord < ActiveRecord::Base
     self.abstract_class = true
+    self.table_name_prefix = "auctify_"
   end
 end

--- a/app/models/auctify/sale/auction.rb
+++ b/app/models/auctify/sale/auction.rb
@@ -99,6 +99,8 @@ module Auctify
         in_sale? || accepted?
       end
 
+
+
       private
         def buyer_vs_bidding_consistence
           return true if buyer.blank? && sold_price.blank?

--- a/app/models/auctify/sales_pack.rb
+++ b/app/models/auctify/sales_pack.rb
@@ -3,5 +3,22 @@
 module Auctify
   class SalesPack < ApplicationRecord
     has_many :sales, class_name: "Auctify::Sale::Base", foreign_key: :pack_id, inverse_of: :pack, dependent: :nullify
+    # has_many :items, through: :sales
+
+    validates :title,
+              presence: true,
+              uniqueness: true
+
+    scope :ordered, -> { order(id: :desc) }
+
+    def items
+      @items ||= sales.collect(&:item) # TODO: make it Arel/Association like
+      # used_polymorhic_classes = sales.pluck(:item_type).uniq
+      # classes_with_table_names = used_polymorhic_classes.collect { |pc| [pc, pc.constantize.table_name] }
+    end
+
+    def to_label
+      title
+    end
   end
 end

--- a/app/views/auctify/bidder_registrations/edit.html.erb
+++ b/app/views/auctify/bidder_registrations/edit.html.erb
@@ -3,4 +3,4 @@
 <%= render 'form', bidder_registration: @bidder_registration %>
 
 <%= link_to 'Show', @bidder_registration %> |
-<%= link_to 'Back', bidder_registrations_path %>
+<%= link_to 'Back', auctify_bidder_registrations_path %>

--- a/app/views/auctify/bidder_registrations/index.html.erb
+++ b/app/views/auctify/bidder_registrations/index.html.erb
@@ -21,7 +21,7 @@
         <td><%= bidder_registration.aasm_state %></td>
         <td><%= bidder_registration.handled_at %></td>
         <td><%= link_to 'Show', bidder_registration %></td>
-        <td><%= link_to 'Edit', edit_bidder_registration_path(bidder_registration) %></td>
+        <td><%= link_to 'Edit', edit_auctify_bidder_registration_path(bidder_registration) %></td>
         <td><%= link_to 'Destroy', bidder_registration, method: :delete, data: { confirm: 'Are you sure?' } %></td>
       </tr>
     <% end %>
@@ -30,4 +30,4 @@
 
 <br>
 
-<%= link_to 'New Bidder Registration', new_bidder_registration_path %>
+<%= link_to 'New Bidder Registration', new_auctify_bidder_registration_path %>

--- a/app/views/auctify/bidder_registrations/new.html.erb
+++ b/app/views/auctify/bidder_registrations/new.html.erb
@@ -2,4 +2,4 @@
 
 <%= render 'form', bidder_registration: @bidder_registration %>
 
-<%= link_to 'Back', bidder_registrations_path %>
+<%= link_to 'Back', auctify_bidder_registrations_path %>

--- a/app/views/auctify/bidder_registrations/show.html.erb
+++ b/app/views/auctify/bidder_registrations/show.html.erb
@@ -20,5 +20,5 @@
   <%= @bidder_registration.handled_at %>
 </p>
 
-<%= link_to 'Edit', edit_bidder_registration_path(@bidder_registration) %> |
-<%= link_to 'Back', bidder_registrations_path %>
+<%= link_to 'Edit', edit_auctify_bidder_registration_path(@bidder_registration) %> |
+<%= link_to 'Back', auctify_bidder_registrations_path %>

--- a/app/views/auctify/bids/edit.html.erb
+++ b/app/views/auctify/bids/edit.html.erb
@@ -3,4 +3,4 @@
 <%= render 'form', bid: @bid %>
 
 <%= link_to 'Show', @bid %> |
-<%= link_to 'Back', bids_path %>
+<%= link_to 'Back', auctify_bids_path %>

--- a/app/views/auctify/bids/index.html.erb
+++ b/app/views/auctify/bids/index.html.erb
@@ -19,7 +19,7 @@
         <td><%= bid.price %></td>
         <td><%= bid.max_price %></td>
         <td><%= link_to 'Show', bid %></td>
-        <td><%= link_to 'Edit', edit_bid_path(bid) %></td>
+        <td><%= link_to 'Edit', edit_auctify_bid_path(bid) %></td>
         <td><%= link_to 'Destroy', bid, method: :delete, data: { confirm: 'Are you sure?' } %></td>
       </tr>
     <% end %>
@@ -28,4 +28,4 @@
 
 <br>
 
-<%= link_to 'New Bid', new_bid_path %>
+<%= link_to 'New Bid', new_auctify_bid_path %>

--- a/app/views/auctify/bids/new.html.erb
+++ b/app/views/auctify/bids/new.html.erb
@@ -2,4 +2,4 @@
 
 <%= render 'form', bid: @bid %>
 
-<%= link_to 'Back', bids_path %>
+<%= link_to 'Back', auctify_bids_path %>

--- a/app/views/auctify/bids/show.html.erb
+++ b/app/views/auctify/bids/show.html.erb
@@ -15,5 +15,5 @@
   <%= @bid.max_price %>
 </p>
 
-<%= link_to 'Edit', edit_bid_path(@bid) %> |
-<%= link_to 'Back', bids_path %>
+<%= link_to 'Edit', edit_auctify_bid_path(@bid) %> |
+<%= link_to 'Back', auctify_bids_path %>

--- a/app/views/auctify/sales/_form.html.erb
+++ b/app/views/auctify/sales/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_with(model: sale, scope: :sale, url: sales_path, local: true) do |form| %>
+<%= form_with(model: sale, scope: :sale, url:auctify_sales_path, local: true) do |form| %>
   <% if sale.errors.any? %>
     <div id="error_explanation">
       <h2><%= pluralize(sale.errors.count, "error") %> prohibited this sale from being saved:</h2>

--- a/app/views/auctify/sales/edit.html.erb
+++ b/app/views/auctify/sales/edit.html.erb
@@ -2,5 +2,5 @@
 
 <%= render 'form', sale: @sale %>
 
-<%= link_to 'Show', sale_path(@sale) %> |
-<%= link_to 'Back', sales_path %>
+<%= link_to 'Show',auctify_sale_path(@sale) %> |
+<%= link_to 'Back',auctify_sales_path %>

--- a/app/views/auctify/sales/index.html.erb
+++ b/app/views/auctify/sales/index.html.erb
@@ -2,7 +2,7 @@
 
 <h1>Sales</h1>
 <% unless params[:list_all].to_s == "1" %>
-  Listed only published sales. Do you want <%= link_to 'all', sales_path(params: { list_all: 1}) %>?
+  Listed only published sales. Do you want <%= link_to 'all',auctify_sales_path(params: { list_all: 1}) %>?
 <% end %>
 
 <table>
@@ -23,9 +23,9 @@
         <td><%= sale.buyer&.name %></td>
         <td><%= sale.item.name %></td>
         <td><%= sale.published? ? "YES" : sale.published_at  %></td>
-        <td><%= link_to 'Show', sale_path(sale) %></td>
-        <td><%= link_to 'Edit', edit_sale_path(sale) %></td>
-        <td><%= link_to 'Destroy', sale_path(sale), method: :delete, data: { confirm: 'Are you sure?' } %></td>
+        <td><%= link_to 'Show',auctify_sale_path(sale) %></td>
+        <td><%= link_to 'Edit', edit_auctify_sale_path(sale) %></td>
+        <td><%= link_to 'Destroy',auctify_sale_path(sale), method: :delete, data: { confirm: 'Are you sure?' } %></td>
       </tr>
     <% end %>
   </tbody>
@@ -33,4 +33,4 @@
 
 <br>
 
-<%= link_to 'New Sale', new_sale_path %>
+<%= link_to 'New Sale', new_auctify_sale_path %>

--- a/app/views/auctify/sales/new.html.erb
+++ b/app/views/auctify/sales/new.html.erb
@@ -2,4 +2,4 @@
 
 <%= render 'form', sale: @sale %>
 
-<%= link_to 'Back', sales_path %>
+<%= link_to 'Back',auctify_sales_path %>

--- a/app/views/auctify/sales/show.html.erb
+++ b/app/views/auctify/sales/show.html.erb
@@ -15,5 +15,5 @@
   <%= @sale.item.name %>
 </p>
 
-<%= link_to 'Edit', edit_sale_path(@sale) %> |
-<%= link_to 'Back', sales_path %>
+<%= link_to 'Edit', edit_auctify_sale_path(@sale) %> |
+<%= link_to 'Back',auctify_sales_path %>

--- a/app/views/auctify/sales_packs/edit.html.erb
+++ b/app/views/auctify/sales_packs/edit.html.erb
@@ -3,4 +3,4 @@
 <%= render 'form', sales_pack: @sales_pack %>
 
 <%= link_to 'Show', @sales_pack %> |
-<%= link_to 'Back', sales_packs_path %>
+<%= link_to 'Back', auctify_sales_packs_path %>

--- a/app/views/auctify/sales_packs/index.html.erb
+++ b/app/views/auctify/sales_packs/index.html.erb
@@ -27,7 +27,7 @@
         <td><%= sales_pack.place %></td>
         <td><%= sales_pack.published %></td>
         <td><%= link_to 'Show', sales_pack %></td>
-        <td><%= link_to 'Edit', edit_sales_pack_path(sales_pack) %></td>
+        <td><%= link_to 'Edit', edit_auctify_sales_pack_path(sales_pack) %></td>
         <td><%= link_to 'Destroy', sales_pack, method: :delete, data: { confirm: 'Are you sure?' } %></td>
       </tr>
     <% end %>
@@ -36,4 +36,4 @@
 
 <br>
 
-<%= link_to 'New Sales Pack', new_sales_pack_path %>
+<%= link_to 'New Sales Pack', new_auctify_sales_pack_path %>

--- a/app/views/auctify/sales_packs/new.html.erb
+++ b/app/views/auctify/sales_packs/new.html.erb
@@ -2,4 +2,4 @@
 
 <%= render 'form', sales_pack: @sales_pack %>
 
-<%= link_to 'Back', sales_packs_path %>
+<%= link_to 'Back', auctify_sales_packs_path %>

--- a/app/views/auctify/sales_packs/show.html.erb
+++ b/app/views/auctify/sales_packs/show.html.erb
@@ -35,5 +35,5 @@
   <%= @sales_pack.published %>
 </p>
 
-<%= link_to 'Edit', edit_sales_pack_path(@sales_pack) %> |
-<%= link_to 'Back', sales_packs_path %>
+<%= link_to 'Edit', edit_auctify_sales_pack_path(@sales_pack) %> |
+<%= link_to 'Back', auctify_sales_packs_path %>

--- a/config/locales/auctify.cs.yml
+++ b/config/locales/auctify.cs.yml
@@ -3,36 +3,54 @@ cs:
     models:
       auctify/sale/base:
       auctify/sale/retail:
+        one: Přímý prodej
+        few: Přímé prodeje
+        other: Přímých prodejů
       auctify/sale/auction:
-        one: Aukce (položky)
-        few: Aukcí
-        other: Aukcí
+        one: Aukční položka
+        few: Aukční položky
+        other: Aukčních položek
       auctify/bid:
         one: Přihoz
         few: Příhozy
         other: Příhozů
-      auctify/sale/auction_pack:
-        one: Aukční celek
-        few: Aukční celky
-        other: Aukčních celků
+      auctify/sales_pack:
+        one: Aukce
+        few: Aukce (auctify)
+        other: Aukcí
       auctify/bidder_registration:
         one: Registrace dražebníka
         other: Registrace dražebníků
 
     attributes:
+      auctify/sales_pack:
+        title: Název
+        description: Popisek
+        position: Pozice
+        slug: Varianta názvu pro odkazy
+        time_frame: Termín
+        place: Místo konání
+        published: Zveřejněno
+        sales_count: Počet položek
+        sales: Položky
       auctify/sale/base:
         buyer: Kupec
         seller: Prodejce
         item: Zboží
-      auctify/sale/retail:
-      auctify/sale/auction:
         aasm_state: Stav
+        published_at: Zveřejněno
+      auctify/sale/retail:
+        created_at: Vytvořen
+        updated_at: Změněn
+      auctify/sale/auction:
         bid_steps_ladder: Žebříček příhozů
         offered_price: Vyvolávací cena
         current_price: Aktuální cena
         sold_price: Vydražená cena
         created_at: Vytvořena
         updated_at: Změněna
+        reserve_price: Rezervovaná cena
+        ends_at: Předpokládaný konec
       auctify/bid:
         price: Výše příhozu
         max_price: Maximální výše příhozu

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,8 +1,10 @@
 # frozen_string_literal: true
 
 Auctify::Engine.routes.draw do
-  resources :sales_packs
-  resources :bids
-  resources :bidder_registrations
-  resources :sales
+  namespace :auctify do
+    resources :sales_packs
+    resources :bids
+    resources :bidder_registrations
+    resources :sales
+  end
 end

--- a/db/migrate/20210420133243_remove_selling_price_from_auctify_sales.rb
+++ b/db/migrate/20210420133243_remove_selling_price_from_auctify_sales.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class RemoveSellingPriceFromAuctifySales < ActiveRecord::Migration[6.0]
+  def change
+    remove_column :auctify_sales, :selling_price, :decimal
+  end
+end

--- a/db/migrate/20210421093652_add_number_to_auctify_sales.rb
+++ b/db/migrate/20210421093652_add_number_to_auctify_sales.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddNumberToAuctifySales < ActiveRecord::Migration[6.0]
+  def change
+    add_column :auctify_sales, :number, :string
+  end
+end

--- a/lib/auctify/engine.rb
+++ b/lib/auctify/engine.rb
@@ -5,7 +5,8 @@ require_relative "../../app/models/auctify/behaviors"
 
 module Auctify
   class Engine < ::Rails::Engine
-    isolate_namespace Auctify
+    # we choose not to use this `isolate_namespace Auctify`
+    # there was then problem when using from main app with routes (`url_for(Auctify::SalesPack)` => `NoMethodError: sales_pack_url`)
 
     initializer :append_migrations do |app|
       unless app.root.to_s.include? root.to_s

--- a/lib/auctify/engine.rb
+++ b/lib/auctify/engine.rb
@@ -6,7 +6,8 @@ require_relative "../../app/models/auctify/behaviors"
 module Auctify
   class Engine < ::Rails::Engine
     # we choose not to use this `isolate_namespace Auctify`
-    # there was then problem when using from main app with routes (`url_for(Auctify::SalesPack)` => `NoMethodError: sales_pack_url`)
+    # there was problem with routes when using it from main app,
+    # (`url_for(Auctify::SalesPack)` => `NoMethodError: sales_pack_url`)
 
     initializer :append_migrations do |app|
       unless app.root.to_s.include? root.to_s

--- a/routes.txt
+++ b/routes.txt
@@ -15,7 +15,7 @@
                                       PATCH  /users/:id(.:format)                                                                     users#update
                                       PUT    /users/:id(.:format)                                                                     users#update
                                       DELETE /users/:id(.:format)                                                                     users#destroy
-                       auctify_engine        /auctify                                                                                 Auctify::Engine
+                              auctify        /                                                                                        Auctify::Engine
                                  root GET    /                                                                                        users#index
         rails_postmark_inbound_emails POST   /rails/action_mailbox/postmark/inbound_emails(.:format)                                  action_mailbox/ingresses/postmark/inbound_emails#create
            rails_relay_inbound_emails POST   /rails/action_mailbox/relay/inbound_emails(.:format)                                     action_mailbox/ingresses/relay/inbound_emails#create

--- a/routes.txt
+++ b/routes.txt
@@ -1,0 +1,73 @@
+                               Prefix Verb   URI Pattern                                                                              Controller#Action
+                               things GET    /things(.:format)                                                                        things#index
+                                      POST   /things(.:format)                                                                        things#create
+                            new_thing GET    /things/new(.:format)                                                                    things#new
+                           edit_thing GET    /things/:id/edit(.:format)                                                               things#edit
+                                thing GET    /things/:id(.:format)                                                                    things#show
+                                      PATCH  /things/:id(.:format)                                                                    things#update
+                                      PUT    /things/:id(.:format)                                                                    things#update
+                                      DELETE /things/:id(.:format)                                                                    things#destroy
+                                users GET    /users(.:format)                                                                         users#index
+                                      POST   /users(.:format)                                                                         users#create
+                             new_user GET    /users/new(.:format)                                                                     users#new
+                            edit_user GET    /users/:id/edit(.:format)                                                                users#edit
+                                 user GET    /users/:id(.:format)                                                                     users#show
+                                      PATCH  /users/:id(.:format)                                                                     users#update
+                                      PUT    /users/:id(.:format)                                                                     users#update
+                                      DELETE /users/:id(.:format)                                                                     users#destroy
+                       auctify_engine        /auctify                                                                                 Auctify::Engine
+                                 root GET    /                                                                                        users#index
+        rails_postmark_inbound_emails POST   /rails/action_mailbox/postmark/inbound_emails(.:format)                                  action_mailbox/ingresses/postmark/inbound_emails#create
+           rails_relay_inbound_emails POST   /rails/action_mailbox/relay/inbound_emails(.:format)                                     action_mailbox/ingresses/relay/inbound_emails#create
+        rails_sendgrid_inbound_emails POST   /rails/action_mailbox/sendgrid/inbound_emails(.:format)                                  action_mailbox/ingresses/sendgrid/inbound_emails#create
+  rails_mandrill_inbound_health_check GET    /rails/action_mailbox/mandrill/inbound_emails(.:format)                                  action_mailbox/ingresses/mandrill/inbound_emails#health_check
+        rails_mandrill_inbound_emails POST   /rails/action_mailbox/mandrill/inbound_emails(.:format)                                  action_mailbox/ingresses/mandrill/inbound_emails#create
+         rails_mailgun_inbound_emails POST   /rails/action_mailbox/mailgun/inbound_emails/mime(.:format)                              action_mailbox/ingresses/mailgun/inbound_emails#create
+       rails_conductor_inbound_emails GET    /rails/conductor/action_mailbox/inbound_emails(.:format)                                 rails/conductor/action_mailbox/inbound_emails#index
+                                      POST   /rails/conductor/action_mailbox/inbound_emails(.:format)                                 rails/conductor/action_mailbox/inbound_emails#create
+    new_rails_conductor_inbound_email GET    /rails/conductor/action_mailbox/inbound_emails/new(.:format)                             rails/conductor/action_mailbox/inbound_emails#new
+   edit_rails_conductor_inbound_email GET    /rails/conductor/action_mailbox/inbound_emails/:id/edit(.:format)                        rails/conductor/action_mailbox/inbound_emails#edit
+        rails_conductor_inbound_email GET    /rails/conductor/action_mailbox/inbound_emails/:id(.:format)                             rails/conductor/action_mailbox/inbound_emails#show
+                                      PATCH  /rails/conductor/action_mailbox/inbound_emails/:id(.:format)                             rails/conductor/action_mailbox/inbound_emails#update
+                                      PUT    /rails/conductor/action_mailbox/inbound_emails/:id(.:format)                             rails/conductor/action_mailbox/inbound_emails#update
+                                      DELETE /rails/conductor/action_mailbox/inbound_emails/:id(.:format)                             rails/conductor/action_mailbox/inbound_emails#destroy
+rails_conductor_inbound_email_reroute POST   /rails/conductor/action_mailbox/:inbound_email_id/reroute(.:format)                      rails/conductor/action_mailbox/reroutes#create
+                   rails_service_blob GET    /rails/active_storage/blobs/:signed_id/*filename(.:format)                               active_storage/blobs#show
+            rails_blob_representation GET    /rails/active_storage/representations/:signed_blob_id/:variation_key/*filename(.:format) active_storage/representations#show
+                   rails_disk_service GET    /rails/active_storage/disk/:encoded_key/*filename(.:format)                              active_storage/disk#show
+            update_rails_disk_service PUT    /rails/active_storage/disk/:encoded_token(.:format)                                      active_storage/disk#update
+                 rails_direct_uploads POST   /rails/active_storage/direct_uploads(.:format)                                           active_storage/direct_uploads#create
+
+Routes for Auctify::Engine:
+             auctify_sales_packs GET    /auctify/sales_packs(.:format)                   auctify/sales_packs#index
+                                 POST   /auctify/sales_packs(.:format)                   auctify/sales_packs#create
+          new_auctify_sales_pack GET    /auctify/sales_packs/new(.:format)               auctify/sales_packs#new
+         edit_auctify_sales_pack GET    /auctify/sales_packs/:id/edit(.:format)          auctify/sales_packs#edit
+              auctify_sales_pack GET    /auctify/sales_packs/:id(.:format)               auctify/sales_packs#show
+                                 PATCH  /auctify/sales_packs/:id(.:format)               auctify/sales_packs#update
+                                 PUT    /auctify/sales_packs/:id(.:format)               auctify/sales_packs#update
+                                 DELETE /auctify/sales_packs/:id(.:format)               auctify/sales_packs#destroy
+                    auctify_bids GET    /auctify/bids(.:format)                          auctify/bids#index
+                                 POST   /auctify/bids(.:format)                          auctify/bids#create
+                 new_auctify_bid GET    /auctify/bids/new(.:format)                      auctify/bids#new
+                edit_auctify_bid GET    /auctify/bids/:id/edit(.:format)                 auctify/bids#edit
+                     auctify_bid GET    /auctify/bids/:id(.:format)                      auctify/bids#show
+                                 PATCH  /auctify/bids/:id(.:format)                      auctify/bids#update
+                                 PUT    /auctify/bids/:id(.:format)                      auctify/bids#update
+                                 DELETE /auctify/bids/:id(.:format)                      auctify/bids#destroy
+    auctify_bidder_registrations GET    /auctify/bidder_registrations(.:format)          auctify/bidder_registrations#index
+                                 POST   /auctify/bidder_registrations(.:format)          auctify/bidder_registrations#create
+ new_auctify_bidder_registration GET    /auctify/bidder_registrations/new(.:format)      auctify/bidder_registrations#new
+edit_auctify_bidder_registration GET    /auctify/bidder_registrations/:id/edit(.:format) auctify/bidder_registrations#edit
+     auctify_bidder_registration GET    /auctify/bidder_registrations/:id(.:format)      auctify/bidder_registrations#show
+                                 PATCH  /auctify/bidder_registrations/:id(.:format)      auctify/bidder_registrations#update
+                                 PUT    /auctify/bidder_registrations/:id(.:format)      auctify/bidder_registrations#update
+                                 DELETE /auctify/bidder_registrations/:id(.:format)      auctify/bidder_registrations#destroy
+                   auctify_sales GET    /auctify/sales(.:format)                         auctify/sales#index
+                                 POST   /auctify/sales(.:format)                         auctify/sales#create
+                new_auctify_sale GET    /auctify/sales/new(.:format)                     auctify/sales#new
+               edit_auctify_sale GET    /auctify/sales/:id/edit(.:format)                auctify/sales#edit
+                    auctify_sale GET    /auctify/sales/:id(.:format)                     auctify/sales#show
+                                 PATCH  /auctify/sales/:id(.:format)                     auctify/sales#update
+                                 PUT    /auctify/sales/:id(.:format)                     auctify/sales#update
+                                 DELETE /auctify/sales/:id(.:format)                     auctify/sales#destroy

--- a/test/concerns/auctify/seller_test.rb
+++ b/test/concerns/auctify/seller_test.rb
@@ -16,7 +16,7 @@ module Auctify
       end
 
       assert SellerTestUser.new(name: "Krutibrko").respond_to?(:sales)
-      assert SellerTestUser.new(name: "Krutibrko").respond_to?(:auctions)
+      assert SellerTestUser.new(name: "Krutibrko").respond_to?(:auction_sales)
       assert SellerTestUser.new(name: "Krutibrko").respond_to?(:offer_to_sale!)
     end
 

--- a/test/controllers/auctify/bidder_registrations_controller_test.rb
+++ b/test/controllers/auctify/bidder_registrations_controller_test.rb
@@ -11,52 +11,52 @@ module Auctify
     end
 
     test "should get index" do
-      get bidder_registrations_url
+      get auctify_bidder_registrations_url
       assert_response :success
     end
 
     test "should get new" do
-      get new_bidder_registration_url
+      get new_auctify_bidder_registration_url
       assert_response :success
     end
 
     test "should create bidder_registration" do
       auction = auctify_sales(:auction_in_progress)
       assert_difference("Auctify::BidderRegistration.count") do
-        post bidder_registrations_url,
+        post auctify_bidder_registrations_url,
              params: { bidder_registration: { auction_id: auction.id,
                                               bidder_id: users(:lucifer).id,
                                               bidder_type: "User" } }
       end
 
-      assert_redirected_to bidder_registration_url(BidderRegistration.last)
+      assert_redirected_to auctify_bidder_registration_url(BidderRegistration.last)
     end
 
     test "should show bidder_registration" do
-      get bidder_registration_url(@bidder_registration)
+      get auctify_bidder_registration_url(@bidder_registration)
       assert_response :success
     end
 
     test "should get edit" do
-      get edit_bidder_registration_url(@bidder_registration)
+      get edit_auctify_bidder_registration_url(@bidder_registration)
       assert_response :success
     end
 
     test "should update bidder_registration" do
-      patch bidder_registration_url(@bidder_registration),
+      patch auctify_bidder_registration_url(@bidder_registration),
             params: { bidder_registration: { auction_id: @bidder_registration.auction_id,
                                              bidder_id: @bidder_registration.bidder_id,
                                              bidder_type: @bidder_registration.bidder_type,
                                              handled_at: @bidder_registration.handled_at } }
-      assert_redirected_to bidder_registration_url(@bidder_registration)
+      assert_redirected_to auctify_bidder_registration_url(@bidder_registration)
     end
 
     test "should destroy bidder_registration" do
       assert_difference("Auctify::BidderRegistration.count", -1) do
-        delete bidder_registration_url(@bidder_registration)
+        delete auctify_bidder_registration_url(@bidder_registration)
       end
 
-      assert_redirected_to bidder_registrations_url
+      assert_redirected_to auctify_bidder_registrations_url
     end
   end
 end

--- a/test/controllers/auctify/bids_controller_test.rb
+++ b/test/controllers/auctify/bids_controller_test.rb
@@ -11,46 +11,46 @@ module Auctify
     end
 
     test "should get index" do
-      get bids_url
+      get auctify_bids_url
       assert_response :success
     end
 
     test "should get new" do
-      get new_bid_url
+      get new_auctify_bid_url
       assert_response :success
     end
 
     test "should create bid" do
       assert_difference("Bid.count") do
-        post bids_url,
+        post auctify_bids_url,
 params: { bid: { max_price: @bid.max_price, price: @bid.price, registration_id: @bid.registration.id } }
       end
 
-      assert_redirected_to bid_url(Bid.last)
+      assert_redirected_to auctify_bid_url(Bid.last)
     end
 
     test "should show bid" do
-      get bid_url(@bid)
+      get auctify_bid_url(@bid)
       assert_response :success
     end
 
     test "should get edit" do
-      get edit_bid_url(@bid)
+      get edit_auctify_bid_url(@bid)
       assert_response :success
     end
 
     test "should update bid" do
-      patch bid_url(@bid),
+      patch auctify_bid_url(@bid),
 params: { bid: { max_price: @bid.max_price, price: @bid.price, registration_id: @bid.registration_id } }
-      assert_redirected_to bid_url(@bid)
+      assert_redirected_to auctify_bid_url(@bid)
     end
 
     test "should destroy bid" do
       assert_difference("Bid.count", -1) do
-        delete bid_url(@bid)
+        delete auctify_bid_url(@bid)
       end
 
-      assert_redirected_to bids_url
+      assert_redirected_to auctify_bids_url
     end
   end
 end

--- a/test/controllers/auctify/sales_controller_test.rb
+++ b/test/controllers/auctify/sales_controller_test.rb
@@ -41,7 +41,7 @@ module Auctify
     end
 
     test "should get new" do
-      get new_sale_url
+      get new_auctify_sale_url
       assert_response :success
 
       assert_select_with(User.all, :seller)
@@ -57,11 +57,11 @@ module Auctify
                                item_auctify_id: @sale.item_auctify_id } }
       end
 
-      assert_redirected_to sale_url(Sale::Base.last)
+      assert_redirected_to auctify_sale_url(Sale::Base.last)
     end
 
     test "should show sale" do
-      get sale_url(@sale)
+      get auctify_sale_url(@sale)
 
       assert_response :success
       assert response.body.include?(@sale.item.name)
@@ -70,19 +70,19 @@ module Auctify
     end
 
     test "should get edit" do
-      get edit_sale_url(@sale)
+      get edit_auctify_sale_url(@sale)
       assert_response :success
 
       assert_select_with(User.all, :seller, @sale.seller)
     end
 
     test "should update sale" do
-      patch sale_url(@sale),
+      patch auctify_sale_url(@sale),
             params: { sale: { seller_auctify_id: users(:adam).auctify_id,
                               buyer_auctify_id: nil,
                               item_auctify_id: things(:leaf).auctify_id } }
 
-      assert_redirected_to sale_url(@sale)
+      assert_redirected_to auctify_sale_url(@sale)
 
       assert_equal users(:adam), @sale.reload.seller
       assert_nil @sale.buyer
@@ -91,7 +91,7 @@ module Auctify
 
     test "should destroy sale" do
       assert_difference("Sale::Base.count", -1) do
-        delete sale_url(@sale)
+        delete auctify_sale_url(@sale)
       end
 
       assert_redirected_to sales_url

--- a/test/controllers/auctify/sales_controller_test.rb
+++ b/test/controllers/auctify/sales_controller_test.rb
@@ -11,7 +11,7 @@ module Auctify
     end
 
     test "should get index with published and not ended sales" do
-      get sales_url
+      get auctify_sales_url
 
       assert_response :success
 
@@ -28,7 +28,7 @@ module Auctify
     end
 
     test "should get index with any sales if param list_all=1 is present" do
-      get sales_url, params: { list_all: "1" }
+      get auctify_sales_url, params: { list_all: "1" }
 
       assert_response :success
 
@@ -51,7 +51,7 @@ module Auctify
 
     test "should create sale" do
       assert_difference("Sale::Base.count") do
-        post sales_url,
+        post auctify_sales_url,
              params: { sale: { seller_auctify_id: @sale.seller_auctify_id,
                                buyer_auctify_id: @sale.buyer_auctify_id,
                                item_auctify_id: @sale.item_auctify_id } }
@@ -94,7 +94,7 @@ module Auctify
         delete auctify_sale_url(@sale)
       end
 
-      assert_redirected_to sales_url
+      assert_redirected_to auctify_sales_url
     end
 
     def assert_select_with(records, type, selected = nil)

--- a/test/controllers/auctify/sales_packs_controller_test.rb
+++ b/test/controllers/auctify/sales_packs_controller_test.rb
@@ -11,18 +11,18 @@ module Auctify
     end
 
     test "should get index" do
-      get sales_packs_url
+      get auctify_sales_packs_url
       assert_response :success
     end
 
     test "should get new" do
-      get new_sales_pack_url
+      get new_auctify_sales_pack_url
       assert_response :success
     end
 
     test "should create sales_pack" do
       assert_difference("Auctify::SalesPack.count") do
-        post sales_packs_url, params: { sales_pack: { description: @sales_pack.description,
+        post auctify_sales_packs_url, params: { sales_pack: { description: @sales_pack.description,
                                                       place: @sales_pack.place,
                                                       position: @sales_pack.position,
                                                       published: @sales_pack.published,
@@ -31,36 +31,36 @@ module Auctify
                                                       title: @sales_pack.title } }
       end
 
-      assert_redirected_to sales_pack_url(SalesPack.last)
+      assert_redirected_to auctify_sales_pack_url(SalesPack.last)
     end
 
     test "should show sales_pack" do
-      get sales_pack_url(@sales_pack)
+      get auctify_sales_pack_url(@sales_pack)
       assert_response :success
     end
 
     test "should get edit" do
-      get edit_sales_pack_url(@sales_pack)
+      get edit_auctify_sales_pack_url(@sales_pack)
       assert_response :success
     end
 
     test "should update sales_pack" do
-      patch sales_pack_url(@sales_pack), params: { sales_pack: { description: @sales_pack.description,
+      patch auctify_sales_pack_url(@sales_pack), params: { sales_pack: { description: @sales_pack.description,
                                                                  place: @sales_pack.place,
                                                                  position: @sales_pack.position,
                                                                  published: @sales_pack.published,
                                                                  slug: @sales_pack.slug,
                                                                  time_frame: @sales_pack.time_frame,
                                                                  title: @sales_pack.title } }
-      assert_redirected_to sales_pack_url(@sales_pack)
+      assert_redirected_to auctify_sales_pack_url(@sales_pack)
     end
 
     test "should destroy sales_pack" do
       assert_difference("Auctify::SalesPack.count", -1) do
-        delete sales_pack_url(@sales_pack)
+        delete auctify_sales_pack_url(@sales_pack)
       end
 
-      assert_redirected_to sales_packs_url
+      assert_redirected_to auctify_sales_packs_url
     end
   end
 end

--- a/test/dummy/app/views/layouts/application.html.erb
+++ b/test/dummy/app/views/layouts/application.html.erb
@@ -12,7 +12,7 @@
   <body>
     <%= link_to("Users", users_path) %>
     <%= link_to("Things", things_path) %>
-    | <%= link_to("Sales", auctify.sales_path) %>
+    | <%= link_to("Sales", auctify.auctify_sales_path) %>
     <hr />
     <%= yield %>
   </body>

--- a/test/dummy/config/routes.rb
+++ b/test/dummy/config/routes.rb
@@ -3,7 +3,7 @@
 Rails.application.routes.draw do
   resources :things
   resources :users
-  mount Auctify::Engine => "/auctify"
+  mount Auctify::Engine => "/", as: "auctify"
 
   root to: "users#index"
 end

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_04_19_083321) do
+ActiveRecord::Schema.define(version: 2021_04_21_093652) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -59,7 +59,6 @@ ActiveRecord::Schema.define(version: 2021_04_19_083321) do
     t.datetime "updated_at", precision: 6, null: false
     t.string "type", default: "Auctify::Sale::Base"
     t.string "aasm_state", default: "offered", null: false
-    t.decimal "selling_price"
     t.datetime "published_at"
     t.decimal "offered_price"
     t.decimal "current_price"
@@ -69,6 +68,7 @@ ActiveRecord::Schema.define(version: 2021_04_19_083321) do
     t.bigint "pack_id"
     t.datetime "ends_at"
     t.integer "position"
+    t.string "number"
     t.index ["buyer_type", "buyer_id"], name: "index_auctify_sales_on_buyer_type_and_buyer_id"
     t.index ["item_type", "item_id"], name: "index_auctify_sales_on_item_type_and_item_id"
     t.index ["pack_id"], name: "index_auctify_sales_on_pack_id"

--- a/test/system/auctify/bidder_registrations_test.rb
+++ b/test/system/auctify/bidder_registrations_test.rb
@@ -9,12 +9,12 @@ module Auctify
     end
 
     test "visiting the index" do
-      visit bidder_registrations_url
+      visit auctify_bidder_registrations_url
       assert_selector "h1", text: "Bidder Registrations"
     end
 
     test "creating a Bidder registration" do
-      visit bidder_registrations_url
+      visit auctify_bidder_registrations_url
       click_on "New Bidder Registration"
 
       fill_in "Aasm state", with: @bidder_registration.aasm_state
@@ -30,7 +30,7 @@ module Auctify
     end
 
     test "updating a Bidder registration" do
-      visit bidder_registrations_url
+      visit auctify_bidder_registrations_url
       click_on "Edit", match: :first
 
       fill_in "Aasm state", with: @bidder_registration.aasm_state
@@ -46,7 +46,7 @@ module Auctify
     end
 
     test "destroying a Bidder registration" do
-      visit bidder_registrations_url
+      visit auctify_bidder_registrations_url
       page.accept_confirm do
         click_on "Destroy", match: :first
       end

--- a/test/system/auctify/bids_test.rb
+++ b/test/system/auctify/bids_test.rb
@@ -9,12 +9,12 @@ module Auctify
     end
 
     test "visiting the index" do
-      visit bids_url
+      visit auctify_bids_url
       assert_selector "h1", text: "Bids"
     end
 
     test "creating a Bid" do
-      visit bids_url
+      visit auctify_bids_url
       click_on "New Bid"
 
       fill_in "Max price", with: @bid.max_price
@@ -27,7 +27,7 @@ module Auctify
     end
 
     test "updating a Bid" do
-      visit bids_url
+      visit auctify_bids_url
       click_on "Edit", match: :first
 
       fill_in "Max price", with: @bid.max_price
@@ -40,7 +40,7 @@ module Auctify
     end
 
     test "destroying a Bid" do
-      visit bids_url
+      visit auctify_bids_url
       page.accept_confirm do
         click_on "Destroy", match: :first
       end

--- a/test/system/auctify/sales_test.rb
+++ b/test/system/auctify/sales_test.rb
@@ -9,12 +9,12 @@ module Auctify
     end
 
     test "visiting the index" do
-      visit sales_url
+      visitauctify_sales_url
       assert_selector "h1", text: "Sales"
     end
 
     test "creating a Sale" do
-      visit sales_url
+      visitauctify_sales_url
       click_on "New Sale"
 
       fill_in "Buyer", with: @sale.buyer_id
@@ -30,7 +30,7 @@ module Auctify
     end
 
     test "updating a Sale" do
-      visit sales_url
+      visitauctify_sales_url
       click_on "Edit", match: :first
 
       fill_in "Buyer", with: @sale.buyer_id
@@ -46,7 +46,7 @@ module Auctify
     end
 
     test "destroying a Sale" do
-      visit sales_url
+      visitauctify_sales_url
       page.accept_confirm do
         click_on "Destroy", match: :first
       end


### PR DESCRIPTION
because of wrong routing in main app (was `url_for([:console, Auctify::SalesPack]) => console_sales_packs_path` instead `console_auctify_sales_packs_path`) 
Gem handle it on its'own. Mounting point should be '/' (so URLs than be `/auctify/sales_packs`) 